### PR TITLE
Fix typed message parsing for announcement `USERNOTICE`s without `msg-param-color` tag

### DIFF
--- a/src/msg/snapshots/tmi__msg__user_notice__tests__parse_user_notice_announcement_no_color.snap
+++ b/src/msg/snapshots/tmi__msg__user_notice__tests__parse_user_notice_announcement_no_color.snap
@@ -1,0 +1,34 @@
+---
+source: src/msg/user_notice.rs
+expression: "f(\"@badge-info=;badges=moderator/1;color=#1E90FF;display-name=vetricbot;emotes=;flags=;id=8c0fea53-7827-4165-8848-8e512b59beed;login=vetricbot;mod=1;msg-id=announcement;room-id=404660262;subscriber=0;system-msg=;tmi-sent-ts=1738762344755;user-id=955666532;user-type=mod;vip=0 :tmi.twitch.tv USERNOTICE #creepycode :sample\")"
+---
+UserNotice {
+    channel: "#creepycode",
+    channel_id: "404660262",
+    sender: Some(
+        User {
+            id: "955666532",
+            login: "vetricbot",
+            name: "vetricbot",
+        },
+    ),
+    text: Some(
+        "sample",
+    ),
+    system_message: None,
+    event: Announcement(
+        Announcement {
+            highlight_color: "PRIMARY",
+        },
+    ),
+    event_id: "announcement",
+    badges: [
+        Moderator,
+    ],
+    emotes: "",
+    color: Some(
+        "#1E90FF",
+    ),
+    message_id: "8c0fea53-7827-4165-8848-8e512b59beed",
+    timestamp: 2025-02-05T13:32:24.755Z,
+}

--- a/src/msg/user_notice.rs
+++ b/src/msg/user_notice.rs
@@ -715,6 +715,11 @@ mod tests {
   fn parse_user_notice_announcement() {
     assert_irc_snapshot!(UserNotice, "@emotes=;login=pajbot;vip=0;tmi-sent-ts=1695554663565;flags=;mod=1;subscriber=1;id=bb1bec25-8f26-4ba3-a084-a6a2ca332f00;badge-info=subscriber/93;system-msg=;user-id=82008718;user-type=mod;room-id=11148817;badges=moderator/1,subscriber/3072;msg-param-color=PRIMARY;msg-id=announcement;color=#2E8B57;display-name=pajbot :tmi.twitch.tv USERNOTICE #pajlada :$ping xd");
   }
+  
+  #[test]
+  fn parse_user_notice_announcement_no_color() {
+    assert_irc_snapshot!(UserNotice, "@badge-info=;badges=moderator/1;color=#1E90FF;display-name=vetricbot;emotes=;flags=;id=8c0fea53-7827-4165-8848-8e512b59beed;login=vetricbot;mod=1;msg-id=announcement;room-id=404660262;subscriber=0;system-msg=;tmi-sent-ts=1738762344755;user-id=955666532;user-type=mod;vip=0 :tmi.twitch.tv USERNOTICE #creepycode :sample")
+  }
 
   #[test]
   fn parse_sub() {

--- a/src/msg/user_notice.rs
+++ b/src/msg/user_notice.rs
@@ -571,7 +571,7 @@ impl<'src> UserNotice<'src> {
       ),
       "announcement" => (
         Event::Announcement(Announcement {
-          highlight_color: message.tag(Tag::MsgParamColor)?.into(),
+          highlight_color: message.tag(Tag::MsgParamColor).unwrap_or("PRIMARY").into(),
         }),
         false,
       ),


### PR DESCRIPTION
I encountered this randomly. Seems like twitch is skipping the `msg-param-color` tag for announcements that are done with legacy IRC commands (Still used on Twitch for TV afaik). Currently, this leads to a `MessageParseError`. This PR just defaults to `PRIMARY` in such cases (same as native web chat).