### PR TITLE
feat!: make sender total gifts optional on event submysterygift for subtember

### DIFF
--- a/src/msg/snapshots/tmi__msg__user_notice__tests__parse_subgift_subtember.snap
+++ b/src/msg/snapshots/tmi__msg__user_notice__tests__parse_subgift_subtember.snap
@@ -1,0 +1,49 @@
+---
+source: src/msg/user_notice.rs
+expression: "f(\"@badge-info=subscriber/2;badges=subscriber/2,sub-gift-leader/2;color=#FF0000;display-name=VALORANT;emotes=;flags=;id=d4726c39-a5f3-4db6-99f9-b8e16176eb98;login=valorant;mod=0;msg-id=submysterygift;msg-param-community-gift-id=6234683999269936493;msg-param-gift-match-bonus-count=1;msg-param-gift-match-extra-count=0;msg-param-gift-match-gifter-display-name=isntyourname123;msg-param-gift-match=bonus;msg-param-mass-gift-count=1;msg-param-origin-id=6234683999269936493;msg-param-sub-plan=1000;room-id=719949561;subscriber=1;system-msg=We\\\\sadded\\\\s1\\\\sGift\\\\sSubs\\\\sto\\\\sisntyourname123's\\\\sgift!;tmi-sent-ts=1758924748531;user-id=490592527;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #crelly\")"
+---
+UserNotice {
+    channel: "#crelly",
+    channel_id: "719949561",
+    sender: Some(
+        User {
+            id: "490592527",
+            login: "valorant",
+            name: "VALORANT",
+        },
+    ),
+    text: None,
+    system_message: Some(
+        "We\\sadded\\s1\\sGift\\sSubs\\sto\\sisntyourname123's\\sgift!",
+    ),
+    event: SubMysteryGift(
+        SubMysteryGift {
+            count: 1,
+            sender_total_gifts: None,
+            sub_plan: "1000",
+        },
+    ),
+    event_id: "submysterygift",
+    badges: [
+        Subscriber(
+            Subscriber {
+                version: "2",
+                months: "2",
+                months_n: 2,
+            },
+        ),
+        Other(
+            BadgeData {
+                name: "sub-gift-leader",
+                version: "2",
+                extra: None,
+            },
+        ),
+    ],
+    emotes: "",
+    color: Some(
+        "#FF0000",
+    ),
+    message_id: "d4726c39-a5f3-4db6-99f9-b8e16176eb98",
+    timestamp: 2025-09-26T22:12:28.531Z,
+}

--- a/src/msg/snapshots/tmi__msg__user_notice__tests__parse_submysterygift.snap
+++ b/src/msg/snapshots/tmi__msg__user_notice__tests__parse_submysterygift.snap
@@ -19,7 +19,9 @@ UserNotice {
     event: SubMysteryGift(
         SubMysteryGift {
             count: 20,
-            sender_total_gifts: 100,
+            sender_total_gifts: Some(
+                100,
+            ),
             sub_plan: "1000",
         },
     ),

--- a/src/msg/user_notice.rs
+++ b/src/msg/user_notice.rs
@@ -278,7 +278,8 @@ generate_getters! {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubMysteryGift<'src> {
   count: u64,
-  sender_total_gifts: u64,
+  /// This count is [`None`] for automated gifters like Twitch and Valorant during SUBtember
+  sender_total_gifts: Option<u32>,
   sub_plan: Cow<'src, str>,
 }
 
@@ -288,7 +289,7 @@ generate_getters! {
     count -> u64,
 
     /// Total number of gifts the sender has gifted in this channel.
-    sender_total_gifts -> u64,
+    sender_total_gifts -> Option<u32>,
 
     /// Subcription tier/plan.
     /// For example:
@@ -536,7 +537,7 @@ impl<'src> UserNotice<'src> {
             .and_then(|v| v.parse().ok())?,
           sender_total_gifts: message
             .tag(Tag::MsgParamSenderCount)
-            .and_then(|v| v.parse().ok())?,
+            .and_then(|v| v.parse().ok()),
           sub_plan: message.tag(Tag::MsgParamSubPlan)?.into(),
         }),
         false,
@@ -892,5 +893,11 @@ mod tests {
   #[test]
   fn roundtrip_bitsbadgetier() {
     assert_irc_roundtrip!(UserNotice, "@badge-info=;badges=sub-gifter/50;color=;display-name=AdamAtReflectStudios;emotes=;flags=;id=7f1336e4-f84a-4510-809d-e57bf50af0cc;login=adamatreflectstudios;mod=0;msg-id=rewardgift;msg-param-domain=pride_megacommerce_2020;msg-param-selected-count=100;msg-param-total-reward-count=100;msg-param-trigger-amount=20;msg-param-trigger-type=SUBGIFT;room-id=71092938;subscriber=0;system-msg=AdamAtReflectStudios's\\sGift\\sshared\\srewards\\sto\\s100\\sothers\\sin\\sChat!;tmi-sent-ts=1594583778756;user-id=211711554;user-type= :tmi.twitch.tv USERNOTICE #xqcow");
+  }
+
+  #[cfg(feature = "serde")]
+  #[test]
+  fn todo_test() {
+    assert_irc_roundtrip!(UserNotice, "@badge-info=subscriber/2;badges=subscriber/2,sub-gift-leader/2;color=#FF0000;display-name=VALORANT;emotes=;flags=;id=d4726c39-a5f3-4db6-99f9-b8e16176eb98;login=valorant;mod=0;msg-id=submysterygift;msg-param-community-gift-id=6234683999269936493;msg-param-gift-match-bonus-count=1;msg-param-gift-match-extra-count=0;msg-param-gift-match-gifter-display-name=isntyourname123;msg-param-gift-match=bonus;msg-param-mass-gift-count=1;msg-param-origin-id=6234683999269936493;msg-param-sub-plan=1000;room-id=719949561;subscriber=1;system-msg=We\\sadded\\s1\\sGift\\sSubs\\sto\\sisntyourname123's\\sgift!;tmi-sent-ts=1758924748531;user-id=490592527;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #crelly");
   }
 }

--- a/src/msg/user_notice.rs
+++ b/src/msg/user_notice.rs
@@ -799,6 +799,11 @@ mod tests {
     assert_irc_snapshot!(UserNotice, "@badge-info=;badges=sub-gifter/50;color=;display-name=AdamAtReflectStudios;emotes=;flags=;id=7f1336e4-f84a-4510-809d-e57bf50af0cc;login=adamatreflectstudios;mod=0;msg-id=rewardgift;msg-param-domain=pride_megacommerce_2020;msg-param-selected-count=100;msg-param-total-reward-count=100;msg-param-trigger-amount=20;msg-param-trigger-type=SUBGIFT;room-id=71092938;subscriber=0;system-msg=AdamAtReflectStudios's\\sGift\\sshared\\srewards\\sto\\s100\\sothers\\sin\\sChat!;tmi-sent-ts=1594583778756;user-id=211711554;user-type= :tmi.twitch.tv USERNOTICE #xqcow");
   }
 
+  #[test]
+  fn parse_subgift_subtember() {
+    assert_irc_snapshot!(UserNotice, "@badge-info=subscriber/2;badges=subscriber/2,sub-gift-leader/2;color=#FF0000;display-name=VALORANT;emotes=;flags=;id=d4726c39-a5f3-4db6-99f9-b8e16176eb98;login=valorant;mod=0;msg-id=submysterygift;msg-param-community-gift-id=6234683999269936493;msg-param-gift-match-bonus-count=1;msg-param-gift-match-extra-count=0;msg-param-gift-match-gifter-display-name=isntyourname123;msg-param-gift-match=bonus;msg-param-mass-gift-count=1;msg-param-origin-id=6234683999269936493;msg-param-sub-plan=1000;room-id=719949561;subscriber=1;system-msg=We\\sadded\\s1\\sGift\\sSubs\\sto\\sisntyourname123's\\sgift!;tmi-sent-ts=1758924748531;user-id=490592527;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #crelly");
+  }
+
   #[cfg(feature = "serde")]
   #[test]
   fn roundtrip_user_notice_announcement() {
@@ -897,7 +902,7 @@ mod tests {
 
   #[cfg(feature = "serde")]
   #[test]
-  fn todo_test() {
+  fn roundtrip_subgift_subtember() {
     assert_irc_roundtrip!(UserNotice, "@badge-info=subscriber/2;badges=subscriber/2,sub-gift-leader/2;color=#FF0000;display-name=VALORANT;emotes=;flags=;id=d4726c39-a5f3-4db6-99f9-b8e16176eb98;login=valorant;mod=0;msg-id=submysterygift;msg-param-community-gift-id=6234683999269936493;msg-param-gift-match-bonus-count=1;msg-param-gift-match-extra-count=0;msg-param-gift-match-gifter-display-name=isntyourname123;msg-param-gift-match=bonus;msg-param-mass-gift-count=1;msg-param-origin-id=6234683999269936493;msg-param-sub-plan=1000;room-id=719949561;subscriber=1;system-msg=We\\sadded\\s1\\sGift\\sSubs\\sto\\sisntyourname123's\\sgift!;tmi-sent-ts=1758924748531;user-id=490592527;user-type=;vip=0 :tmi.twitch.tv USERNOTICE #crelly");
   }
 }


### PR DESCRIPTION
PR for #15

Makes `sender_total_gifts` field optional to account for bonus sub gifts during SUBtember on `Event::SubMysteryGift` for USERNOTICE